### PR TITLE
Update colab tutorial

### DIFF
--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -78,7 +78,7 @@
     "    from google.colab import drive\n",
     "    drive.mount('/content/drive')\n",
     "    import os\n",
-    "    os.chdir('dimelo')   \n",
+    "    os.chdir('dimelo_v2')   \n",
     "except:\n",
     "    pass"
    ]

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -54,10 +54,10 @@
     "    # Install modkit\n",
     "    !conda install nanoporetech::modkit==0.2.4\n",
     "    # Clone the repo, change the active path to be inside the repo, and install the package\n",
-    "    !rm -r dimelo\n",
-    "    !git clone -b modkit_parsing_beta https://github.com/streetslab/dimelo\n",
+    "    !rm -r dimelo_v2\n",
+    "    !git clone https://github.com/streetslab/dimelo_v2\n",
     "    import os\n",
-    "    os.chdir('dimelo')\n",
+    "    os.chdir('dimelo_v2')\n",
     "    !pip install ipywidgets==7.7.1 .\n"
    ]
   },
@@ -1541,9 +1541,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "dimelo_modkit_3.11",
+   "display_name": "dimelo_modkit_parsing",
    "language": "python",
-   "name": "dimelo_modkit_3.11"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1555,7 +1555,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.7"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed installation paths in the colab install section of the tutorial notebook to point to the temporary forked repo.