### PR TITLE
Feature/dm 186,dm 187 modkit monitoring and browser bugfixes

### DIFF
--- a/dimelo/.ipynb_checkpoints/plot_read_browser-checkpoint.py
+++ b/dimelo/.ipynb_checkpoints/plot_read_browser-checkpoint.py
@@ -66,6 +66,13 @@ def plot_read_browser(
         sort_by=sort_by,
         calculate_mod_fractions=False,
     )
+    
+    mod_vector_index = entry_labels.index("mod_vector")
+    
+    if (read_tuples[0][mod_vector_index].dtype == np.bool_):
+        raise ValueError(
+            "A threshold has been applied to this .h5 single read data. plot_read_browser must be used with an .h5 file extracted using thresh=None."
+        )
 
     read_extent_df, mod_event_df = format_browser_data(
         read_tuples=read_tuples, entry_labels=entry_labels
@@ -142,7 +149,7 @@ def format_browser_data(
     # TODO: Dropping duplicates should hide the "overdrawing" problem when reads are duplicated in the dataset. Is this a problem or the intended behavior?
     # Get two separate dataframes:
     # * represents the read extents, to draw the grey lines
-    
+
     # Added the read_name subsetting to avoid an index mapping error in make_browser_figure
     # caused by the read metadata for the same read with different motifs having slight
     # start and end offsets in some cases, when using Dorado or PacBio data. These 1-5bp
@@ -151,7 +158,7 @@ def format_browser_data(
     # which then cause non-unique indices for mapping in collapse mode
     read_extent_df = read_df[
         ["read_start", "read_end", "y_index", "read_name"]
-    ].drop_duplicates(subset=['read_name'])
+    ].drop_duplicates(subset=["read_name"])
     # * represents the methylation events
     mod_event_df = (
         read_df[["y_index", "read_name", "motif", "pos_vector", "prob_vector"]]

--- a/dimelo/.ipynb_checkpoints/plot_read_browser-checkpoint.py
+++ b/dimelo/.ipynb_checkpoints/plot_read_browser-checkpoint.py
@@ -142,7 +142,7 @@ def format_browser_data(
     # TODO: Dropping duplicates should hide the "overdrawing" problem when reads are duplicated in the dataset. Is this a problem or the intended behavior?
     # Get two separate dataframes:
     # * represents the read extents, to draw the grey lines
-
+    
     # Added the read_name subsetting to avoid an index mapping error in make_browser_figure
     # caused by the read metadata for the same read with different motifs having slight
     # start and end offsets in some cases, when using Dorado or PacBio data. These 1-5bp
@@ -151,7 +151,7 @@ def format_browser_data(
     # which then cause non-unique indices for mapping in collapse mode
     read_extent_df = read_df[
         ["read_start", "read_end", "y_index", "read_name"]
-    ].drop_duplicates(subset=["read_name"])
+    ].drop_duplicates(subset=['read_name'])
     # * represents the methylation events
     mod_event_df = (
         read_df[["y_index", "read_name", "motif", "pos_vector", "prob_vector"]]

--- a/dimelo/.ipynb_checkpoints/plot_reads-checkpoint.py
+++ b/dimelo/.ipynb_checkpoints/plot_reads-checkpoint.py
@@ -1,0 +1,136 @@
+"""
+I'm conflicted about how to handle some of this.
+
+There are two different ways of doing single read plotting: "rectangular" and "whole read".
+"rectangular" means displaying exactly the requested region.
+"whole read" means displaying the entirety of any read overlapping the requested region.
+Probably need separate methods for all of this? Is there shared functionality? Do they live in the same file? Etc.
+
+I'm beginning to lose the thread of where we check for regions making sense.
+Maybe this is an argument for an internal region class that makes checking easy? I don't know.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import seaborn as sns
+from matplotlib.axes import Axes
+
+from . import load_processed, utils
+
+
+def plot_reads(
+    mod_file_name: str | Path,
+    regions: str | Path | list[str | Path],
+    motifs: list[str],
+    window_size: int | None = None,
+    single_strand: bool = False,
+    regions_5to3prime: bool = False,
+    sort_by: str | list[str] = "shuffle",
+    thresh: float | None = None,
+    relative: bool = True,
+    **kwargs,
+) -> Axes:
+    """
+    Plots centered single reads as a scatterplot, cut off at the boundaries of the requested regions?
+
+    TODO: I feel like this should be able to take in data directly as vectors/other datatypes, not just read from files.
+    TODO: Style-wise, is it cleaner to have it be a match statement or calling a method from a global dict? Cleaner here with a dict, cleaner overall with the match statements?
+    TODO: So far, this is the only method to do plotting without utility methods. Is this reasonable? Is it that unique?
+
+    Args:
+        mod_file_name: path to file containing modification data for single reads
+        regions: path to bed file specifying regions to extract
+        motifs: list of modifications to extract; expected to match mods available in the relevant mod_files
+        window_size: we plot +-window_size//2 from the center of the region(s)
+        single_strand: True means we only grab counts from reads from the same strand as
+            the region of interest, False means we always grab both strands within the regions
+        regions_5to3prime: True means negative strand regions get flipped, False means no flipping. Only works if relative=True
+        sort_by: ordered list for hierarchical sort. Currently only smallest to biggest.
+        thresh: if no threshold has been applied already, this will threshold the mod calls for plotting (method is only boolean)
+        relative: if True, all regions are centered
+
+    Returns:
+        Axes object containing the plot
+    """
+    mod_file_name = Path(mod_file_name)
+    # bed_file_name = Path(bed_file_name)
+    size = kwargs.pop("s", 0.5)
+
+    palette = kwargs.pop("palette", {})
+
+    merged_palette = {**utils.DEFAULT_COLORS, **palette}
+
+    match mod_file_name.suffix:
+        # TODO: Fix how the fake reads options work, and make sure they have the same interface as the real ones.
+        # dimelo/plot_reads.py:63: error: Argument "regions" to "reads_from_fake" has incompatible type "str | Path | list[str | Path]"; expected "Path"  [arg-type]
+        # Will also fix the following error:
+        # dimelo/plot_reads.py:68: error: Incompatible types in assignment (expression has type "dict[Any, Any] | None", variable has type "dict[Any, Any]")  [assignment]
+        case ".fake":
+            reads, read_names, mods, regions_dict = load_processed.reads_from_fake(
+                file=mod_file_name,
+                regions=regions,
+                motifs=motifs,
+            )
+        case _:
+            reads, read_names, mods, regions_dict = (
+                load_processed.readwise_binary_modification_arrays(
+                    file=mod_file_name,
+                    regions=regions,
+                    motifs=motifs,
+                    window_size=window_size,
+                    single_strand=single_strand,
+                    regions_5to3prime=regions_5to3prime,
+                    thresh=thresh,
+                    relative=relative,
+                    sort_by=sort_by,
+                )
+            )
+
+    # Convert data frame where each row represents a read to a data frame where each row represents a single modified position in a read
+    df = pd.DataFrame({"read_name": read_names, "mod": mods, "pos": reads}).explode(
+        "pos"
+    )
+    axes = sns.scatterplot(
+        data=df,
+        x="pos",
+        y="read_name",
+        hue="mod",
+        # palette=colors,
+        s=size,
+        marker="s",
+        linewidth=0,
+        palette=merged_palette,
+        **kwargs,
+    )
+    # Retrieve the existing legend
+    legend = axes.legend_
+
+    # Retrieve legend handles and labels
+    handles, labels = axes.get_legend_handles_labels()
+
+    # Update legend properties
+    # TODO: Do we need to do this now and after?
+    if legend is not None:
+        legend.set_title("Mod")
+
+    # Update marker size for all handles
+    for handle in handles:
+        if hasattr(handle, "set_markersize"):
+            handle.set_markersize(10)  # Set a larger marker size for legend
+
+    # Re-apply the legend with updated handles
+    # TODO: Is this step necessary?
+    axes.legend(handles, labels, title="Mod")
+
+    # TODO: Technically, regions_dict can be None by this point. In that scenario, it will error out when checking the length.
+    # It can be None according to type hints but in the actual logical flow I believe it cannot be None
+    # However, we can easily just check whether it is None here as well, in case we change behavior elsewhere.
+    # Identified with mypy through the following error:
+    # dimelo/plot_reads.py:101: error: Argument 1 to "len" has incompatible type "dict[Any, Any] | None"; expected "Sized"  [arg-type]
+    if relative and regions_dict is not None and len(regions_dict) > 0:
+        region1_start, region1_end, _ = next(iter(regions_dict.values()))[0]
+        effective_window_size = (region1_end - region1_start) // 2
+        axes.set_xlim([-effective_window_size, effective_window_size])
+
+    return axes

--- a/dimelo/.ipynb_checkpoints/run_modkit-checkpoint.py
+++ b/dimelo/.ipynb_checkpoints/run_modkit-checkpoint.py
@@ -186,11 +186,9 @@ def run_with_progress_bars(
                     break  # Handle errors - or just don't!
         process.wait()
         return_code = process.returncode
-        if return_code != 0:
+        if return_code!=0:
             # error_message = f"Process exited with return code {return_code}"
-            raise subprocess.CalledProcessError(
-                return_code, command_list, output=buffer_bytes
-            )
+            raise subprocess.CalledProcessError(return_code, command_list, output=buffer_bytes)
         else:
             return ""
     # Grab output bytes as they come
@@ -356,15 +354,14 @@ def run_with_progress_bars(
                 break  # Handle errors - or just don't!
     process.wait()
     return_code = process.returncode
-    if return_code != 0 or err_flag:
+    if return_code!=0 or err_flag:
+        
         # system_message = f"modkit exited with return code {return_code}"
         # if err_flag:
         #     error_message = system_message+'\nlast state: '+tail_buffer
         # else:
         #     error_message = system_message
-        raise subprocess.CalledProcessError(
-            return_code, command_list, output=buffer_bytes
-        )
+        raise subprocess.CalledProcessError(return_code, command_list, output=buffer_bytes)
 
     elif done_flag or not expect_done:
         try:

--- a/dimelo/parse_bam.py
+++ b/dimelo/parse_bam.py
@@ -669,6 +669,10 @@ def get_alignment_quality(
 
         # get_aligned_pairs returns a list of (read_coord,ref_coord) pairs with None values when not aligned
         # So if we just skip Nones and compare the remainder it'll tell us the accuracy
+        # (in Dorado-basecalled r10 files, as of July 2024, we observe some fraction of reads
+        # with empty read_sequence, despite having intact tags and alignment info. the reason
+        # for this isn't currentyl known, but with this None check we avoid errors in this alignment
+        # checking stage.)
 
         if read_sequence is not None:
             for pos_in_read, pos_in_ref in read.get_aligned_pairs():

--- a/dimelo/parse_bam.py
+++ b/dimelo/parse_bam.py
@@ -670,13 +670,16 @@ def get_alignment_quality(
         # get_aligned_pairs returns a list of (read_coord,ref_coord) pairs with None values when not aligned
         # So if we just skip Nones and compare the remainder it'll tell us the accuracy
 
-        for pos_in_read, pos_in_ref in read.get_aligned_pairs():
-            if pos_in_read is not None and pos_in_ref is not None:
-                total_bases += 1
-                if read_sequence[pos_in_read] == str(
-                    genome_fasta.fetch(read.reference_name, pos_in_ref, pos_in_ref + 1)
-                ):
-                    correct_bases += 1
+        if read_sequence is not None:
+            for pos_in_read, pos_in_ref in read.get_aligned_pairs():
+                if pos_in_read is not None and pos_in_ref is not None:
+                    total_bases += 1
+                    if read_sequence[pos_in_read] == str(
+                        genome_fasta.fetch(
+                            read.reference_name, pos_in_ref, pos_in_ref + 1
+                        )
+                    ):
+                        correct_bases += 1
 
     return correct_bases, total_bases
 

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -67,6 +67,13 @@ def plot_read_browser(
         calculate_mod_fractions=False,
     )
 
+    mod_vector_index = entry_labels.index("mod_vector")
+
+    if read_tuples[0][mod_vector_index].dtype == np.bool_:
+        raise ValueError(
+            "A threshold has been applied to this .h5 single read data. plot_read_browser must be used with an .h5 file extracted using thresh=None."
+        )
+
     read_extent_df, mod_event_df = format_browser_data(
         read_tuples=read_tuples, entry_labels=entry_labels
     )

--- a/dimelo/run_modkit.py
+++ b/dimelo/run_modkit.py
@@ -9,6 +9,7 @@ import select
 import subprocess
 import sys
 from pathlib import Path
+from typing import Optional, cast
 
 from tqdm.auto import tqdm
 
@@ -106,28 +107,17 @@ def run_with_progress_bars(
     """
 
     # Set up progress bar variables
-    """
-    TODO: There are a lot of mypy errors related to these progress bars:
-    dimelo/run_modkit.py:305: error: Item "None" of "Any | None" has no attribute "n"  [union-attr]
-    dimelo/run_modkit.py:306: error: Item "None" of "Any | None" has no attribute "set_description"  [union-attr]
-    dimelo/run_modkit.py:307: error: Item "None" of "Any | None" has no attribute "refresh"  [union-attr]
-    dimelo/run_modkit.py:308: error: Item "None" of "Any | None" has no attribute "close"  [union-attr]
-    dimelo/run_modkit.py:309: error: Item "None" of "Any | None" has no attribute "n"  [union-attr]
-    dimelo/run_modkit.py:311: error: Item "None" of "Any | None" has no attribute "set_description"  [union-attr]
-    dimelo/run_modkit.py:312: error: Item "None" of "Any | None" has no attribute "refresh"  [union-attr]
-    dimelo/run_modkit.py:313: error: Item "None" of "Any | None" has no attribute "close"  [union-attr]
-    dimelo/run_modkit.py:319: error: Item "None" of "Any | None" has no attribute "close"  [union-attr]
-    dimelo/run_modkit.py:320: error: Item "None" of "Any | None" has no attribute "close"  [union-attr]
-
-    Basically, in whatever way these are set up, the variables can theoretically be uninitialized before they are referenced, which can create bugs.
-    """
-    pbar_pre, pbar_contigs, pbar_chr = None, None, None
     format_pre = "{bar}| {desc} {percentage:3.0f}% | {elapsed}"
     format_contigs = "{bar}| {desc} {percentage:3.0f}% | {elapsed}<{remaining}"
     format_chr = "{bar}| {desc} {percentage:3.0f}%"
+    pbar_pre: Optional[tqdm] = None
+    pbar_contigs: Optional[tqdm] = None
+    pbar_chr: Optional[tqdm] = None
+
     # TODO: Is this the correct type annotation? I think it is, based on approx. line 280
     finding_progress_dict: dict[str, tuple[int, int]] = {}
     in_contig_progress = (0, 1)
+    total_contigs = 0
 
     # Set up output buffer variables
     buffer_bytes = bytearray()
@@ -149,52 +139,9 @@ def run_with_progress_bars(
         close_fds=True,
     )
     os.close(slave_fd)
-
-    if quiet:
-        # We need to grab the outputs for the process to terminate but that's it, don't have to do anything with them in this case
-        while True:
-            ready, _, _ = select.select([master_fd], [], [], 0.1)
-            if ready:
-                try:
-                    data = os.read(master_fd, 1)
-                    if not data:
-                        break  # No more data
-
-                    # buffer_bytes += data  # Accumulate bytes in the buffer
-                    #
-                    # try:
-                    #     # Try to decode the accumulated bytes
-                    #     text = buffer_bytes.decode('utf-8')
-                    #     buffer_bytes.clear()  # Clear the buffer after successful decoding
-                    # # If we have hit an error or modkit is done, just accumulate the rest of the output and then deal with it
-                    # if err_flag or done_flag:
-                    #     tail_buffer+=text
-                    # # If we haven't hit an error or a done state, first check for that
-                    # else :
-                    #     tail_buffer = (tail_buffer + text)[-buffer_size:]
-                    #     if err_str in tail_buffer:
-                    #         index = tail_buffer.find(err_str)
-                    #         tail_buffer = tail_buffer[index:]
-                    #         err_flag = True
-                    #     elif done_str in tail_buffer:
-                    #         index = tail_buffer.find(done_str)
-                    #         tail_buffer = tail_buffer[index-2:]
-                    #         done_flag = True
-                    # except:
-                    #     continue
-                except OSError:
-                    break  # Handle errors - or just don't!
-        process.wait()
-        return_code = process.returncode
-        if return_code != 0:
-            # error_message = f"Process exited with return code {return_code}"
-            raise subprocess.CalledProcessError(
-                return_code, command_list, output=buffer_bytes
-            )
-        else:
-            return ""
     # Grab output bytes as they come
     readout_count = 0
+    progress_bars_initialized = False
     while True:
         ready, _, _ = select.select([master_fd], [], [], 0.1)
         if ready:
@@ -204,119 +151,122 @@ def run_with_progress_bars(
                 if not data:
                     break  # No more data
 
-                buffer_bytes += data  # Accumulate bytes in the buffer
+                if quiet:
+                    continue
+                else:
+                    if not progress_bars_initialized:
+                        pbar_pre = tqdm(
+                            total=100,
+                            desc=f"Step 1: Identify motif locations in {ref_genome.name}",
+                            bar_format=format_pre,
+                        )
+                        pbar_contigs = tqdm(
+                            total=100,
+                            desc=f"Step 2: Parse regions in {input_file.name}",
+                            bar_format=format_contigs,
+                        )
+                        pbar_chr = tqdm(
+                            total=100,
+                            desc="",
+                            bar_format=format_chr,
+                        )
+                        progress_bars_initialized = True
 
-                try:
-                    # Try to decode the accumulated bytes
-                    text = buffer_bytes.decode("utf-8")
-                    readout_count += 1
-                    buffer_bytes.clear()  # Clear the buffer after successful decoding
-                    # If we have hit an error or modkit is done, just accumulate the rest of the output and then deal with it
-                    if err_flag or done_flag:
-                        tail_buffer += text
-                    # If we haven't hit an error or a done state, first check for that
-                    else:
-                        tail_buffer = (tail_buffer + text)[-buffer_size:]
-                        if err_str in tail_buffer:
-                            index = tail_buffer.find(err_str)
-                            tail_buffer = tail_buffer[index:]
-                            err_flag = True
-                        elif done_str in tail_buffer:
-                            index = tail_buffer.find(done_str)
-                            tail_buffer = tail_buffer[index - 2 :]
-                            done_flag = True
-                        # If the process is ongoing, then go through the possible cases and create/adjust pbars accordingly
-                        elif readout_count % progress_granularity == 0:
-                            # We check these in the reverse order from that in which they occur, which I guess will save a tiny
-                            # amount of processing time because we don't check for previous steps when on later steps
-                            if contigs_progress_matches := re.search(
-                                contigs_progress_regex, tail_buffer
-                            ):
-                                # Create and close pbars
-                                if pbar_chr is None or pbar_contigs is None:
-                                    if pbar_pre is not None:
+                    buffer_bytes += data  # Accumulate bytes in the buffer
+
+                    try:
+                        # Try to decode the accumulated bytes
+                        text = buffer_bytes.decode("utf-8")
+                        readout_count += 1
+                        buffer_bytes.clear()  # Clear the buffer after successful decoding
+                        # If we have hit an error or modkit is done, just accumulate the rest of the output and then deal with it
+                        if err_flag or done_flag:
+                            tail_buffer += text
+                        # If we haven't hit an error or a done state, first check for that
+                        else:
+                            tail_buffer = (tail_buffer + text)[-buffer_size:]
+                            if err_str in tail_buffer:
+                                index = tail_buffer.find(err_str)
+                                tail_buffer = tail_buffer[index:]
+                                err_flag = True
+                            elif done_str in tail_buffer:
+                                index = tail_buffer.find(done_str)
+                                tail_buffer = tail_buffer[index - 2 :]
+                                done_flag = True
+                            # If the process is ongoing, then go through the possible cases and create/adjust pbars accordingly
+                            elif readout_count % progress_granularity == 0:
+                                if progress_bars_initialized:
+                                    # If we get here we can be sure the pbars are initialized
+                                    pbar_pre = cast(tqdm, pbar_pre)
+                                    pbar_contigs = cast(tqdm, pbar_contigs)
+                                    # We check these in the reverse order from that in which they occur, which I guess will save a tiny
+                                    # amount of processing time because we don't check for previous steps when on later steps
+                                    if contigs_progress_matches := re.search(
+                                        contigs_progress_regex, tail_buffer
+                                    ):
+                                        # Once we are in the contig progress stage, step 1 is done by definition
                                         pbar_pre.n = 100
                                         pbar_pre.set_description(
-                                            f"Preprocessing complete for motifs {motifs} in {ref_genome.name}"
+                                            f"Step 1 complete. Located {motifs} in {ref_genome.name}"
                                         )
                                         pbar_pre.refresh()
                                         pbar_pre.close()
-                                    pbar_contigs = tqdm(
-                                        total=100,
-                                        desc=f"Processing {input_file.name}",
-                                        bar_format=format_contigs,
-                                    )
-                                    pbar_chr = tqdm(
-                                        total=100,
-                                        desc="",
-                                        bar_format=format_chr,
-                                    )
-                                # This progress bar tracks how many contigs/chromosomes have been processed
-                                current_contig = int(contigs_progress_matches.group(1))
-                                total_contigs = int(contigs_progress_matches.group(2))
-                                pbar_contigs.n = (
-                                    100
-                                    * (
-                                        current_contig
-                                        + (
-                                            in_contig_progress[0]
-                                            / in_contig_progress[1]
-                                            if in_contig_progress[1] > 0
+                                        # This progress bar tracks how many contigs/chromosomes have been processed
+                                        current_contig = int(
+                                            contigs_progress_matches.group(1)
+                                        )
+                                        total_contigs = int(
+                                            contigs_progress_matches.group(2)
+                                        )
+                                        pbar_contigs.n = (
+                                            (
+                                                100
+                                                * (
+                                                    current_contig
+                                                    + (
+                                                        in_contig_progress[0]
+                                                        / in_contig_progress[1]
+                                                        if in_contig_progress[1] > 0
+                                                        else 0
+                                                    )
+                                                )
+                                            )
+                                            / total_contigs
+                                            if total_contigs > 0
                                             else 0
                                         )
-                                    )
-                                ) / total_contigs
-                                pbar_contigs.set_description(
-                                    f"Processing contig {current_contig}/{total_contigs} from {input_file.name}"
-                                )
-                                pbar_contigs.refresh()
+                                        pbar_contigs.set_description(
+                                            f"Step 2: parsing {current_contig}/{total_contigs} from {input_file.name}"
+                                        )
+                                        pbar_contigs.refresh()
 
                             elif single_contig_matches := re.search(
                                 single_contig_regex, tail_buffer
                             ):
-                                # Create and close pbars
-                                if pbar_chr is None or pbar_contigs is None:
-                                    if pbar_pre is not None:
-                                        pbar_pre.n = 100
-                                        pbar_pre.set_description(
-                                            "Preprocessing complete for motifs {motifs} in {ref_genome.name}"
-                                        )
-                                        pbar_pre.refresh()
-                                        pbar_pre.close()
-                                    pbar_contigs = tqdm(
-                                        total=100,
-                                        desc=f"Processing {input_file.name}",
-                                        bar_format=format_contigs,
+                                if progress_bars_initialized:
+                                    # If we get here we can be sure the pbars are initialized
+                                    pbar_chr = cast(tqdm, pbar_chr)
+                                    # This progress bar tracks reads processed within a chromosomes
+                                    chromosome = single_contig_matches.group(3)
+                                    reads_done = int(single_contig_matches.group(1))
+                                    reads_total = int(single_contig_matches.group(2))
+                                    pbar_chr.n = (
+                                        100 * reads_done / reads_total
+                                        if reads_total > 0
+                                        else 0
                                     )
-                                    pbar_chr = tqdm(
-                                        total=100,
-                                        desc="",
-                                        bar_format=format_chr,
+                                    in_contig_progress = (reads_done, reads_total)
+                                    pbar_chr.set_description(
+                                        f"Step 2: {chromosome} {reads_done}/{reads_total} chunks processed"
                                     )
-                                # This progress bar tracks reads processed within a chromosomes
-                                chromosome = single_contig_matches.group(3)
-                                reads_done = int(single_contig_matches.group(1))
-                                reads_total = int(single_contig_matches.group(2))
-                                pbar_chr.n = (
-                                    100 * reads_done / reads_total
-                                    if reads_total > 0
-                                    else 0
-                                )
-                                in_contig_progress = (reads_done, reads_total)
-                                pbar_chr.set_description(
-                                    f"{chromosome}: {reads_done}/{reads_total} reads processed"
-                                )
-                                pbar_chr.refresh()
+                                    pbar_chr.refresh()
 
                             elif find_motifs_matches := re.search(
                                 find_motifs_regex, tail_buffer
                             ):
-                                if pbar_pre is not None:
-                                    # pbar_pre = tqdm(
-                                    #     total=100,
-                                    #     desc='Preprocessing',
-                                    #     bar_format=format_pre,
-                                    # )
+                                if progress_bars_initialized:
+                                    # If we get here we can be sure the pbars are initialized
+                                    pbar_pre = cast(tqdm, pbar_pre)
                                     finding_progress_dict[
                                         find_motifs_matches.group(3)
                                     ] = (
@@ -327,65 +277,85 @@ def run_with_progress_bars(
                                     for num, denom in finding_progress_dict.values():
                                         num_sum += num
                                         denom_sum += denom
-                                    pbar_pre.n = 100 * num_sum / denom_sum
+                                    if denom_sum > 0:
+                                        pbar_pre.n = 100 * num_sum / denom_sum
+                                    else:
+                                        pbar_pre.n = 0
                                     pbar_pre.set_description(
-                                        f"Preprocessing: finding motif(s) {motifs}"
+                                        f"Step 1b: finding motif(s) {motifs}"
                                     )
                                     pbar_pre.refresh()
                             elif load_fasta_match := re.search(
                                 load_fasta_regex, tail_buffer
                             ):
-                                if pbar_pre is None:
-                                    pbar_pre = tqdm(
-                                        total=100,
-                                        desc="Preprocessing",
-                                        bar_format=format_pre,
+                                if progress_bars_initialized:
+                                    # If we get here we can be sure the pbars are initialized
+                                    pbar_pre = cast(tqdm, pbar_pre)
+                                    pbar_pre.n = (
+                                        100 * int(load_fasta_match.group(1)) / 24
                                     )
-                                pbar_pre.n = 100 * int(load_fasta_match.group(1)) / 24
-                                pbar_pre.set_description(
-                                    f"Preprocessing: reading {ref_genome.name}"
-                                )
-                                pbar_pre.refresh()
-                except UnicodeDecodeError:
-                    # If decoding fails, continue accumulating bytes
-                    continue
-                except Exception as e:
-                    print(f"WARNING: unexpected error in progress tracking:\n{e}")
-
+                                    pbar_pre.set_description(
+                                        f"Step 1a: reading {ref_genome.name}"
+                                    )
+                                    pbar_pre.refresh()
+                    except UnicodeDecodeError:
+                        # If decoding fails, continue accumulating bytes
+                        continue
+                    except Exception as e:
+                        raise e
             except OSError:
-                break  # Handle errors - or just don't!
+                break
     process.wait()
     return_code = process.returncode
     if return_code != 0 or err_flag:
-        # system_message = f"modkit exited with return code {return_code}"
-        # if err_flag:
-        #     error_message = system_message+'\nlast state: '+tail_buffer
-        # else:
-        #     error_message = system_message
         raise subprocess.CalledProcessError(
-            return_code, command_list, output=buffer_bytes
+            return_code, command_list, output=tail_buffer
         )
 
     elif done_flag or not expect_done:
-        try:
+        if progress_bars_initialized:
+            pbar_pre = cast(tqdm, pbar_pre)
+            pbar_contigs = cast(tqdm, pbar_contigs)
+            pbar_chr = cast(tqdm, pbar_chr)
+            pbar_pre.close()
             pbar_contigs.n = 100
-            pbar_contigs.set_description(f"All regions complete in {input_file.name}")
+            pbar_contigs.set_description(
+                f"Step 2 complete. {total_contigs} contigs processed from {input_file.name}"
+            )
             pbar_contigs.refresh()
             pbar_contigs.close()
             pbar_chr.n = 100
             ansi_escape_pattern = re.compile(r"(\[2K>)")
-            pbar_chr.set_description(ansi_escape_pattern.sub("", tail_buffer).strip())
+            pbar_chr.set_description(
+                command_list[0]
+                + " "
+                + command_list[1]
+                + " return code "
+                + str(return_code)
+                + " | "
+                + ansi_escape_pattern.sub("", tail_buffer).strip()
+            )
             pbar_chr.refresh()
             pbar_chr.close()
-        except Exception as e:
-            print(f"WARNING: unexpected error in progress tracking:\n{e}")
         return tail_buffer
     else:
-        try:
+        if progress_bars_initialized:
+            pbar_pre = cast(tqdm, pbar_pre)
+            pbar_contigs = cast(tqdm, pbar_contigs)
+            pbar_chr = cast(tqdm, pbar_chr)
+            pbar_pre.close()
+            pbar_contigs.set_description("Unexpected modkit outputs")
+            pbar_contigs.refresh()
             pbar_contigs.close()
+            pbar_chr.set_description(
+                command_list[0]
+                + " "
+                + command_list[1]
+                + " return code "
+                + str(return_code)
+            )
+            pbar_chr.refresh()
             pbar_chr.close()
-        except Exception as e:
-            print(f"WARNING: unexpected error in progress tracking:\n{e}")
         print(
             'WARNING: the modkit command may not have completed normally. Consider re-running with "log=True" if you do not get the expected outputs.'
         )

--- a/dimelo/run_modkit.py
+++ b/dimelo/run_modkit.py
@@ -201,107 +201,109 @@ def run_with_progress_bars(
                                 # We check these in the reverse order from that in which they occur, which I guess will save a tiny
                                 # amount of processing time because we don't check for previous steps when on later steps
                                 # Once we are in the contig progress stage, step 1 is done by definition
-                                if contigs_progress_matches := re.search(
-                                    contigs_progress_regex, tail_buffer
-                                ):
-                                    if progress_bars_initialized:
-                                        # If we get here we can be sure the pbars are initialized
-                                        pbar_pre = cast(tqdm, pbar_pre)
-                                        pbar_contigs = cast(tqdm, pbar_contigs)
-                                        if not region_parsing_started:
-                                            # These are now no longer indicating future steps, but rather counting the actual
-                                            # time for step 2
-                                            pbar_contigs.reset()
-                                            pbar_chr.reset()
-                                            region_parsing_started = True
-                                            # Now that region parsing has started, we can close out the preprocessing pbar
-                                            pbar_pre.n = 100
-                                            pbar_pre.set_description(
-                                                f"Step 1 complete. Located {motifs} in {ref_genome.name}"
-                                            )
-                                            pbar_pre.refresh()
-                                            pbar_pre.close()
-                                        # This progress bar tracks how many contigs/chromosomes have been processed
-                                        current_contig = int(
-                                            contigs_progress_matches.group(1)
-                                        )
-                                        total_contigs = int(
-                                            contigs_progress_matches.group(2)
-                                        )
-                                        pbar_contigs.n = (
-                                            (
-                                                100
-                                                * (
-                                                    current_contig
-                                                    + (
-                                                        in_contig_progress[0]
-                                                        / in_contig_progress[1]
-                                                        if in_contig_progress[1] > 0
-                                                        else 0
-                                                    )
-                                                )
-                                            )
-                                            / total_contigs
-                                            if total_contigs > 0
-                                            else 0
-                                        )
-                                        pbar_contigs.set_description(
-                                            f"Step 2: parsing {current_contig}/{total_contigs} from {input_file.name}"
-                                        )
-                                        pbar_contigs.refresh()
-
-                                elif region_parsing_started and (
-                                    single_contig_matches := re.search(
-                                        single_contig_regex, tail_buffer
+                                if progress_bars_initialized and (
+                                    contigs_progress_matches := re.search(
+                                        contigs_progress_regex, tail_buffer
                                     )
                                 ):
-                                    if progress_bars_initialized:
-                                        # If we get here we can be sure the pbars are initialized
-                                        pbar_chr = cast(tqdm, pbar_chr)
-                                        # This progress bar tracks reads processed within a chromosomes
-                                        chromosome = single_contig_matches.group(3)
-                                        reads_done = int(single_contig_matches.group(1))
-                                        reads_total = int(
-                                            single_contig_matches.group(2)
-                                        )
-                                        pbar_chr.n = (
-                                            100 * reads_done / reads_total
-                                            if reads_total > 0
-                                            else 0
-                                        )
-                                        in_contig_progress = (reads_done, reads_total)
-                                        pbar_chr.set_description(
-                                            f"Step 2: {chromosome} {reads_done}/{reads_total} chunks processed"
-                                        )
-                                        pbar_chr.refresh()
-
-                                elif find_motifs_matches := re.search(
-                                    find_motifs_regex, tail_buffer
-                                ):
-                                    if progress_bars_initialized:
-                                        # If we get here we can be sure the pbars are initialized
-                                        pbar_pre = cast(tqdm, pbar_pre)
-                                        finding_progress_dict[
-                                            find_motifs_matches.group(3)
-                                        ] = (
-                                            int(find_motifs_matches.group(1)),
-                                            int(find_motifs_matches.group(2)),
-                                        )
-                                        num_sum, denom_sum = 0, 0
-                                        for (
-                                            num,
-                                            denom,
-                                        ) in finding_progress_dict.values():
-                                            num_sum += num
-                                            denom_sum += denom
-                                        if denom_sum > 0:
-                                            pbar_pre.n = 100 * num_sum / denom_sum
-                                        else:
-                                            pbar_pre.n = 0
+                                    # If we get here we can be sure the pbars are initialized
+                                    pbar_pre = cast(tqdm, pbar_pre)
+                                    pbar_contigs = cast(tqdm, pbar_contigs)
+                                    if not region_parsing_started:
+                                        # These are now no longer indicating future steps, but rather counting the actual
+                                        # time for step 2
+                                        pbar_contigs.reset()
+                                        pbar_chr.reset()
+                                        region_parsing_started = True
+                                        # Now that region parsing has started, we can close out the preprocessing pbar
+                                        pbar_pre.n = 100
                                         pbar_pre.set_description(
-                                            f"Step 1b: finding motif(s) {motifs}"
+                                            f"Step 1 complete. Located {motifs} in {ref_genome.name}"
                                         )
                                         pbar_pre.refresh()
+                                        pbar_pre.close()
+                                    # This progress bar tracks how many contigs/chromosomes have been processed
+                                    current_contig = int(
+                                        contigs_progress_matches.group(1)
+                                    )
+                                    total_contigs = int(
+                                        contigs_progress_matches.group(2)
+                                    )
+                                    pbar_contigs.n = (
+                                        (
+                                            100
+                                            * (
+                                                current_contig
+                                                + (
+                                                    in_contig_progress[0]
+                                                    / in_contig_progress[1]
+                                                    if in_contig_progress[1] > 0
+                                                    else 0
+                                                )
+                                            )
+                                        )
+                                        / total_contigs
+                                        if total_contigs > 0
+                                        else 0
+                                    )
+                                    pbar_contigs.set_description(
+                                        f"Step 2: parsing {current_contig}/{total_contigs} from {input_file.name}"
+                                    )
+                                    pbar_contigs.refresh()
+                                elif (
+                                    progress_bars_initialized
+                                    and region_parsing_started
+                                    and (
+                                        single_contig_matches := re.search(
+                                            single_contig_regex, tail_buffer
+                                        )
+                                    )
+                                ):
+                                    # If we get here we can be sure the pbars are initialized
+                                    pbar_chr = cast(tqdm, pbar_chr)
+                                    # This progress bar tracks reads processed within a chromosomes
+                                    chromosome = single_contig_matches.group(3)
+                                    reads_done = int(single_contig_matches.group(1))
+                                    reads_total = int(single_contig_matches.group(2))
+                                    pbar_chr.n = (
+                                        100 * reads_done / reads_total
+                                        if reads_total > 0
+                                        else 0
+                                    )
+                                    in_contig_progress = (reads_done, reads_total)
+                                    pbar_chr.set_description(
+                                        f"Step 2: {chromosome} {reads_done}/{reads_total} chunks processed"
+                                    )
+                                    pbar_chr.refresh()
+
+                                elif progress_bars_initialized and (
+                                    find_motifs_matches := re.search(
+                                        find_motifs_regex, tail_buffer
+                                    )
+                                ):
+                                    # If we get here we can be sure the pbars are initialized
+                                    pbar_pre = cast(tqdm, pbar_pre)
+                                    finding_progress_dict[
+                                        find_motifs_matches.group(3)
+                                    ] = (
+                                        int(find_motifs_matches.group(1)),
+                                        int(find_motifs_matches.group(2)),
+                                    )
+                                    num_sum, denom_sum = 0, 0
+                                    for (
+                                        num,
+                                        denom,
+                                    ) in finding_progress_dict.values():
+                                        num_sum += num
+                                        denom_sum += denom
+                                    if denom_sum > 0:
+                                        pbar_pre.n = 100 * num_sum / denom_sum
+                                    else:
+                                        pbar_pre.n = 0
+                                    pbar_pre.set_description(
+                                        f"Step 1b: finding motif(s) {motifs}"
+                                    )
+                                    pbar_pre.refresh()
                                 elif progress_bars_initialized and (
                                     load_fasta_match := re.search(
                                         load_fasta_regex, tail_buffer

--- a/dimelo/test/.ipynb_checkpoints/dimelo_test-checkpoint.py
+++ b/dimelo/test/.ipynb_checkpoints/dimelo_test-checkpoint.py
@@ -1,0 +1,775 @@
+import filecmp
+import gzip
+import pickle
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+from matplotlib.axes import Axes
+
+import dimelo as dm
+from dimelo.test import DiMeLoParsingTestCase, filter_kwargs_for_func
+
+script_location = Path(__file__).parent
+
+with open(
+    script_location / "data" / "test_targets" / "test_matrix.pickle", "rb"
+) as file:
+    test_matrix = pickle.load(file)
+
+
+@pytest.mark.parametrize(
+    "test_case,kwargs,results",
+    [(case, inputs, outputs) for case, (inputs, outputs) in test_matrix.items()],
+)
+class TestParseToPlot(DiMeLoParsingTestCase):
+    """
+    Tests parsing a bam file into a bed.gz pileup and an hdf5 single read file, then tests that each stage
+    of parse_bam -> load_processed -> plotting works correctly, including comparing where applicable.
+
+    This test class requires the output files be bitwise identical, compared to pre-defined reference files.
+    This means that interface changes require replacing these files.
+
+    For integration tests we test interfaces end-to-end.
+    """
+
+    def test_unit__pileup(
+        cls,
+        test_case,
+        kwargs,
+        results,
+    ):
+        kwargs_pileup = filter_kwargs_for_func(dm.parse_bam.pileup, kwargs)
+        kwargs_pileup["output_directory"] = cls.outDir
+        pileup_bed, regions_processed = dm.parse_bam.pileup(
+            **kwargs_pileup,
+            ref_genome=cls.reference_genome,
+        )
+
+        pileup_target, regions_target = results["pileup"]
+
+        if pileup_target is not None and regions_target is not None:
+            # This is necessary because the gzipped files are different on mac vs linux, but the contents should be identical (and are, so far)
+            # Not sure why the compression ratio is better on Linux when both are using pysam.tabix_compress with pysam 0.22.0 and zlib 1.2.13 but whatcha gonna do
+            with gzip.open(pileup_bed, "rt") as f1, gzip.open(
+                pileup_target, "rt"
+            ) as f2:
+                # Read and compare file contents
+                file1_contents = f1.read()
+                file2_contents = f2.read()
+                assert (
+                    file1_contents == file2_contents
+                ), f"{test_case}: {pileup_bed} does not match {pileup_target}."
+            assert filecmp.cmp(
+                regions_processed, regions_target, shallow=False
+            ), f"{test_case}: {regions_processed} does not match {regions_target}."
+        else:
+            print(f"{test_case} skipped for pileup.")
+
+    def test_unit__extract(
+        cls,
+        test_case,
+        kwargs,
+        results,
+    ):
+        kwargs_extract = filter_kwargs_for_func(dm.parse_bam.extract, kwargs)
+        kwargs_extract["output_directory"] = cls.outDir
+        extract_h5, regions_processed = dm.parse_bam.extract(
+            **kwargs_extract,
+            ref_genome=cls.reference_genome,
+            cores=1,
+        )
+
+        extract_target, regions_target = results["extract"]
+
+        if extract_target is not None and regions_target is not None:
+            # The hdf5 files will have a few bits different due to gzip compression timestamps, but comparing the exact size should pass because
+            # the timestamps are not themselves compressed inside the vector gzip objects
+            h5_test = h5py.File(extract_h5)
+            h5_target = h5py.File(extract_target)
+            datasets = [
+                name for name, obj in h5_target.items() if isinstance(obj, h5py.Dataset)
+            ]
+            for dataset in datasets:
+                if dataset in ["threshold"]:
+                    assert h5_test[dataset] == h5_target[dataset] or np.isnan(
+                        h5_test[dataset]
+                    ) == np.isnan(h5_target[dataset])
+                else:
+                    test_dataset = list(h5_test[dataset][:])
+                    target_dataset = list(h5_target[dataset][:])
+                    if dataset in ["mod_vector", "val_vector"]:
+                        assert [
+                            gzip.decompress(test_item.tobytes())
+                            for test_item in test_dataset
+                        ] == [
+                            gzip.decompress(target_item.tobytes())
+                            for target_item in target_dataset
+                        ], f"{test_case}: {dataset} does not match."
+                    else:
+                        assert (
+                            test_dataset == target_dataset
+                        ), f"{test_case}: {dataset} does not match."
+            # assert os.path.getsize(extract_h5) == os.path.getsize(extract_target), f"{test_case}: {extract_h5} does not match {extract_target}."
+            assert filecmp.cmp(
+                regions_processed, regions_target, shallow=False
+            ), f"{test_case}: {regions_processed} does not match {regions_target}."
+        else:
+            print(f"{test_case} skipped for extract.")
+
+    def test_integration__pileup_load_plot(
+        cls,
+        test_case,
+        kwargs,
+        results,
+    ):
+        # This stuff is commented out because if we run this integration test in the same class as the unit test
+        # for parsing, we can cut down total end-to-end testing overhead by about 2x by just using that output
+        #
+        # kwargs_pileup = filter_kwargs_for_func(dm.parse_bam.pileup,kwargs)
+        # kwargs_pileup['output_directory'] = cls.outDir
+        # pileup_bed,_ = dm.parse_bam.pileup(
+        #     **kwargs_pileup,
+        #     ref_genome = cls.reference_genome,
+        # )
+        # We just grab the output from TestParseBam::test_pileup, wasteful to re-run an identical modkit command
+        pileup_bed = cls.outDir / kwargs["output_name"] / "pileup.sorted.bed.gz"
+
+        # If we have results for this pileup, check that the load_processed values are ok out of the output file
+        if results["pileup"][0] is not None:
+            kwargs_counts_from_bedmethyl = filter_kwargs_for_func(
+                dm.load_processed.pileup_counts_from_bedmethyl, kwargs
+            )
+            for motif in kwargs["motifs"]:
+                expected = results["pileup_counts_from_bedmethyl"][motif]
+                actual = dm.load_processed.pileup_counts_from_bedmethyl(
+                    bedmethyl_file=pileup_bed,
+                    motif=motif,
+                    **kwargs_counts_from_bedmethyl,
+                )
+                assert (
+                    actual == expected
+                ), f"{test_case}: Counts for motif {motif} are not equal"
+
+            kwargs_vectors_from_bedmethyl = filter_kwargs_for_func(
+                dm.load_processed.pileup_vectors_from_bedmethyl, kwargs
+            )
+            for motif in kwargs["motifs"]:
+                expected_tuple = results["pileup_vectors_from_bedmethyl"][motif]
+                actual_tuple = dm.load_processed.pileup_vectors_from_bedmethyl(
+                    bedmethyl_file=results["pileup"][0],
+                    motif=motif,
+                    **kwargs_vectors_from_bedmethyl,
+                )
+                assert len(expected_tuple) == len(
+                    actual_tuple
+                ), f"{test_case}: Unexpected number of arrays returned for {motif}"
+
+                for expected, actual in zip(expected_tuple, actual_tuple):
+                    # TODO: The following was the original assertion error message, but it was not written in a functional way. Find a way to make it work as intended.
+                    # assert np.array_equal(expected, actual), f"{test_case}: Arrays for motif {motif} are not equal: expected {value} but got {actual[key]}"
+                    assert np.array_equal(
+                        expected, actual
+                    ), f"{test_case}: Arrays for motif {motif} are not equal."
+        else:
+            print(
+                f"{test_case} loading skipped for pileup_load_plot, continuing to plotting."
+            )
+
+        kwargs_plot_enrichment_plot_enrichment = filter_kwargs_for_func(
+            dm.plot_enrichment.plot_enrichment, kwargs
+        )
+        for motif in kwargs["motifs"]:
+            regions_list = (
+                kwargs["regions"]
+                if isinstance(kwargs["regions"], list)
+                else [kwargs["regions"]]
+            )
+            kwargs_plot_enrichment_plot_enrichment["motifs"] = [
+                motif for _ in regions_list
+            ]
+            ax = dm.plot_enrichment.plot_enrichment(
+                mod_file_names=[pileup_bed for _ in regions_list],
+                regions_list=regions_list,
+                sample_names=["label" for _ in regions_list],
+                **kwargs_plot_enrichment_plot_enrichment,
+            )
+            assert isinstance(ax, Axes), f"{test_case}: plotting failed for {motif}."
+        kwargs_plot_enrichment_profile_plot_enrichment_profile = filter_kwargs_for_func(
+            dm.plot_enrichment_profile.plot_enrichment_profile,
+            kwargs,
+            extra_args=["window_size", "smooth_window"],
+        )
+        for motif in kwargs["motifs"]:
+            regions_list = (
+                kwargs["regions"]
+                if isinstance(kwargs["regions"], list)
+                else [kwargs["regions"]]
+            )
+            kwargs_plot_enrichment_profile_plot_enrichment_profile["motifs"] = [
+                motif for _ in regions_list
+            ]
+            ax = dm.plot_enrichment_profile.plot_enrichment_profile(
+                mod_file_names=[pileup_bed for _ in regions_list],
+                regions_list=regions_list,
+                sample_names=["label" for _ in regions_list],
+                **kwargs_plot_enrichment_profile_plot_enrichment_profile,
+            )
+            assert isinstance(ax, Axes), f"{test_case}: plotting failed for {motif}."
+
+    def test_integration__extract_load_plot(
+        cls,
+        test_case,
+        kwargs,
+        results,
+    ):
+        # This stuff is commented out because if we run this integration test in the same class as the unit test
+        # for parsing, we can cut down total end-to-end testing overhead by about 2x by just using that output
+        #
+        # if results['extract'][0] is None:
+        #     return
+
+        # kwargs_extract = filter_kwargs_for_func(dm.parse_bam.extract,kwargs)
+        # kwargs_extract['output_directory'] = cls.outDir
+        # extract_h5,_ = dm.parse_bam.extract(
+        #     **kwargs_extract,
+        #     ref_genome = cls.reference_genome,
+        # )
+        # We just grab the output from TestParseBam::test_extract, wasteful to re-run an identical modkit command
+        extract_h5 = cls.outDir / kwargs["output_name"] / "reads.combined_basemods.h5"
+
+        # If we have results for this extraction, check that the load_processed values are ok out of the output file
+        if results["extract"][0] is not None:
+            kwargs_read_vectors_from_hdf5 = filter_kwargs_for_func(
+                dm.load_processed.read_vectors_from_hdf5, kwargs
+            )
+            read_data_list, datasets, _ = dm.load_processed.read_vectors_from_hdf5(
+                file=extract_h5,
+                **kwargs_read_vectors_from_hdf5,
+            )
+            read_data_dict = {}
+            # Pull out the data from the first read
+            for idx, dataset in enumerate(datasets):
+                for read_data in read_data_list:
+                    read_data_dict[dataset] = read_data[idx]
+                    break
+            expected = results["read_vectors_from_hdf5"]
+            actual = read_data_dict
+            for key, value in expected.items():
+                if isinstance(value, np.ndarray):
+                    assert np.allclose(
+                        actual[key], expected[key], atol=1e-5
+                    ), f"""{test_case}: Arrays for {key} are not equal
+mismatch at {np.where(value!=actual[key])}
+mismatch values expected {value[np.where(value!=actual[key])]} vs actual {actual[key][np.where(value!=actual[key])]}
+{value[np.where(value!=actual[key])[0]]} vs {actual[key][np.where(value!=actual[key])[0]]}.
+                    """
+                elif isinstance(value, (str, int, bool)):
+                    assert (
+                        actual[key] == expected[key]
+                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                else:
+                    assert np.isclose(
+                        actual[key], value, atol=1e-4
+                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+        else:
+            print("{test_case} skipped for read_vectors_from_hdf5.")
+        kwargs_plot_reads_plot_reads = filter_kwargs_for_func(
+            dm.plot_reads.plot_reads, kwargs
+        )
+        if kwargs["thresh"] is not None:
+            ax = dm.plot_reads.plot_reads(
+                mod_file_name=extract_h5,
+                **kwargs_plot_reads_plot_reads,
+            )
+            assert isinstance(ax, Axes), f"{test_case}: plotting failed."
+        else:  # if the extract parameters did not have a threshold, plot_reads.plot_reads should raise an error
+            with pytest.raises(ValueError) as excinfo:
+                ax = dm.plot_reads.plot_reads(
+                    mod_file_name=extract_h5,
+                    **kwargs_plot_reads_plot_reads,
+                )
+            assert "No threshold has been applied" in str(
+                excinfo.value
+            ), f"{test_case}: unexpected exception {excinfo.value}"
+            # providing a threshold should be enough to run plot_reads.plot_reads without an error
+            kwargs_plot_reads_plot_reads["thresh"] = 0.75
+            ax = dm.plot_reads.plot_reads(
+                mod_file_name=extract_h5,
+                **kwargs_plot_reads_plot_reads,
+            )
+            assert isinstance(ax, Axes), f"{test_case}: plotting failed."
+
+
+@pytest.mark.parametrize(
+    "test_case,kwargs,results",
+    [(case, inputs, outputs) for case, (inputs, outputs) in test_matrix.items()],
+)
+class TestLoadProcessed:
+    """
+    Tests loading values from bed.gz pileups and hdf5 single read files.
+
+    This test class requires that values are identical. It loads from pre-defined reference files.
+    This means that interface changes require replacing these files by re-running the Generate parse_bam
+    outputs section of dimelo/test/generate_test_targets.ipynb.
+    """
+
+    def test_unit__pileup_counts_from_bedmethyl(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_counts_from_bedmethyl = filter_kwargs_for_func(
+                dm.load_processed.pileup_counts_from_bedmethyl, kwargs
+            )
+            for motif in kwargs["motifs"]:
+                expected = results["pileup_counts_from_bedmethyl"][motif]
+                actual = dm.load_processed.pileup_counts_from_bedmethyl(
+                    bedmethyl_file=results["pileup"][0],
+                    motif=motif,
+                    **kwargs_counts_from_bedmethyl,
+                )
+                assert (
+                    actual == expected
+                ), f"{test_case}: Counts for motif {motif} are not equal"
+        else:
+            print(f"{test_case} skipped for pileup_counts_from_bedmethyl.")
+
+    def test_unit__pileup_vectors_from_bedmethyl(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_vectors_from_bedmethyl = filter_kwargs_for_func(
+                dm.load_processed.pileup_vectors_from_bedmethyl, kwargs
+            )
+            for motif in kwargs["motifs"]:
+                expected_tuple = results["pileup_vectors_from_bedmethyl"][motif]
+                actual_tuple = dm.load_processed.pileup_vectors_from_bedmethyl(
+                    bedmethyl_file=results["pileup"][0],
+                    motif=motif,
+                    **kwargs_vectors_from_bedmethyl,
+                )
+                assert len(expected_tuple) == len(
+                    actual_tuple
+                ), f"{test_case}: Unexpected number of arrays returned for {motif}"
+
+                for expected, actual in zip(expected_tuple, actual_tuple):
+                    assert np.array_equal(
+                        expected, actual
+                    ), f"{test_case}: Arrays for motif {motif} are not equal"
+        else:
+            print(f"{test_case} skipped for pileup_vectors_from_bedmethyl.")
+
+    def test_unit__read_vectors_from_hdf5(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["extract"][0] is not None:
+            kwargs_read_vectors_from_hdf5 = filter_kwargs_for_func(
+                dm.load_processed.read_vectors_from_hdf5, kwargs
+            )
+            read_data_list, datasets, _ = dm.load_processed.read_vectors_from_hdf5(
+                file=results["extract"][0],
+                **kwargs_read_vectors_from_hdf5,
+            )
+            read_data_dict = {}
+            # Pull out the data from the first read
+            for idx, dataset in enumerate(datasets):
+                for read_data in read_data_list:
+                    read_data_dict[dataset] = read_data[idx]
+                    break
+            expected = results["read_vectors_from_hdf5"]
+            actual = read_data_dict
+            for key, value in expected.items():
+                if isinstance(value, np.ndarray):
+                    assert np.allclose(
+                        actual[key], expected[key], atol=1e-5
+                    ), f"""{test_case}: Arrays for {key} are not equal
+mismatch at {np.where(value!=actual[key])}
+mismatch values expected {value[np.where(value!=actual[key])]} vs actual {actual[key][np.where(value!=actual[key])]}
+{value[np.where(value!=actual[key])[0]]} vs {actual[key][np.where(value!=actual[key])[0]]}.
+                    """
+                elif isinstance(value, (str, int, bool)):
+                    assert (
+                        actual[key] == expected[key]
+                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+                else:
+                    assert np.isclose(
+                        actual[key], value, atol=1e-4
+                    ), f"{test_case}: Values for {key} are not equal: expected {value} but got {actual[key]}."
+        else:
+            print("{test_case} skipped for read_vectors_from_hdf5.")
+
+
+class TestPlotEnrichmentSynthetic:
+    """
+    Tests plotting functionality in plot_enrichment.
+
+    This test simply checks that we can make plots from synthetic data without raising errors.
+    Appearance of plots is not verified.
+    """
+
+    def test_unit__plot_enrichment_plot_enrichment_synthetic(self):
+        ax = dm.plot_enrichment.plot_enrichment(
+            mod_file_names=["test.fake", "test.fake"],
+            regions_list=["test.bed", "test.bed"],
+            motifs=["A", "A"],
+            sample_names=["a", "b"],
+        )
+        assert isinstance(ax, Axes)
+
+    def test_unit__plot_enrichment_by_modification_synthetic(self):
+        ax = dm.plot_enrichment.by_modification(
+            mod_file_name="test.fake", regions="test.bed", motifs=["A", "C"]
+        )
+        assert isinstance(ax, Axes)
+
+    def test_unit__plot_enrichment_by_regions_synthetic(self):
+        ax = dm.plot_enrichment.by_regions(
+            mod_file_name="test.fake",
+            regions_list=["test1.bed", "test2.bed"],
+            motif="A",
+        )
+        assert isinstance(ax, Axes)
+
+    def test_unit__plot_enrichment_by_dataset_synthetic(self):
+        ax = dm.plot_enrichment.by_dataset(
+            mod_file_names=["test1.fake", "test2.fake"], regions="test.bed", motif="A"
+        )
+        assert isinstance(ax, Axes)
+
+
+@pytest.mark.parametrize(
+    "test_case,kwargs,results",
+    [(case, inputs, outputs) for case, (inputs, outputs) in test_matrix.items()],
+)
+class TestPlotEnrichment:
+    def test_unit__plot_enrichment_plot_enrichment(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_plot_enrichment_plot_enrichment = filter_kwargs_for_func(
+                dm.plot_enrichment.plot_enrichment, kwargs
+            )
+            for motif in kwargs["motifs"]:
+                regions_list = (
+                    kwargs["regions"]
+                    if isinstance(kwargs["regions"], list)
+                    else [kwargs["regions"]]
+                )
+                kwargs_plot_enrichment_plot_enrichment["motifs"] = [
+                    motif for _ in regions_list
+                ]
+                ax = dm.plot_enrichment.plot_enrichment(
+                    mod_file_names=[results["pileup"][0] for _ in regions_list],
+                    regions_list=regions_list,
+                    sample_names=["label" for _ in regions_list],
+                    **kwargs_plot_enrichment_plot_enrichment,
+                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
+        else:
+            print(f"{test_case} skipped for plot_enrichment.plot_enrichment.")
+
+    def test_unit__plot_enrichment_by_regions(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_plot_enrichment_by_regions = filter_kwargs_for_func(
+                dm.plot_enrichment.by_regions, kwargs
+            )
+            for motif in kwargs["motifs"]:
+                regions_list = (
+                    kwargs["regions"]
+                    if isinstance(kwargs["regions"], list)
+                    else [kwargs["regions"]]
+                )
+                ax = dm.plot_enrichment.by_regions(
+                    mod_file_name=results["pileup"][0],
+                    regions_list=regions_list,
+                    motif=motif,
+                    sample_names=["label" for _ in regions_list],
+                    **kwargs_plot_enrichment_by_regions,
+                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
+        else:
+            print(f"{test_case} skipped for plot_enrichment.by_regions.")
+
+    def test_unit__plot_enrichment_by_modification(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_plot_enrichment_by_modification = filter_kwargs_for_func(
+                dm.plot_enrichment.by_modification, kwargs
+            )
+            ax = dm.plot_enrichment.by_modification(
+                mod_file_name=results["pileup"][0],
+                **kwargs_plot_enrichment_by_modification,
+            )
+            assert isinstance(ax, Axes), f"{test_case}: plotting failed."
+        else:
+            print(f"{test_case} skipped for plot_enrichment.by_modification.")
+
+    def test_unit__plot_enrichment_by_dataset(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_plot_enrichment_by_dataset = filter_kwargs_for_func(
+                dm.plot_enrichment.by_dataset, kwargs
+            )
+            for motif in kwargs["motifs"]:
+                ax = dm.plot_enrichment.by_dataset(
+                    mod_file_names=[results["pileup"][0]],
+                    motif=motif,
+                    **kwargs_plot_enrichment_by_dataset,
+                )
+                assert isinstance(ax, Axes), f"{test_case}: plotting failed."
+        else:
+            print(f"{test_case} skipped for plot_enrichment.by_dataset.")
+
+
+class TestPlotEnrichmentProfileSynthetic:
+    """
+    Tests plotting functionality in plot_enrichment_profile.
+
+    This test simply checks that we can make plots from synthetic data without raising errors.
+    Appearance of plots is not verified.
+    """
+
+    def test_unit__plot_enrichment_profile_plot_enrichment_profile_synthetic(self):
+        ax = dm.plot_enrichment_profile.plot_enrichment_profile(
+            mod_file_names=["test1.fake", "test2.fake"],
+            regions_list=["test1.bed", "test2.bed"],
+            motifs=["A", "C"],
+            window_size=500,
+            sample_names=["sample1", "sample2"],
+            smooth_window=50,
+        )
+        assert isinstance(ax, Axes)
+
+    def test_unit__plot_enrichment_profile_by_modification_synthetic(self):
+        ax = dm.plot_enrichment_profile.by_modification(
+            mod_file_name="test.fake",
+            regions="test.bed",
+            window_size=500,
+            motifs=["A", "C"],
+            smooth_window=50,
+        )
+        assert isinstance(ax, Axes)
+
+    def test_unit__plot_enrichment_profile_by_region_synthetic(self):
+        ax = dm.plot_enrichment_profile.by_regions(
+            mod_file_name="test.fake",
+            regions_list=["test1.bed", "test2.bed"],
+            motif="A",
+            window_size=500,
+            sample_names=["on target", "off target"],
+            smooth_window=50,
+        )
+        assert isinstance(ax, Axes)
+
+    def test_unit__plot_enrichment_profile_by_dataset_synthetic(self):
+        ax = dm.plot_enrichment_profile.by_dataset(
+            mod_file_names=["test1.fake", "test2.fake"],
+            regions="test.bed",
+            motif="A",
+            window_size=500,
+            sample_names=["experiment 1", "experiment 2"],
+            smooth_window=50,
+        )
+        assert isinstance(ax, Axes)
+
+
+@pytest.mark.parametrize(
+    "test_case,kwargs,results",
+    [(case, inputs, outputs) for case, (inputs, outputs) in test_matrix.items()],
+)
+class TestPlotEnrichmentProfile:
+    def test_unit__plot_enrichment_profile_plot_enrichment_profile(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_plot_enrichment_profile_plot_enrichment_profile = (
+                filter_kwargs_for_func(
+                    dm.plot_enrichment_profile.plot_enrichment_profile,
+                    kwargs,
+                    extra_args=["window_size", "smooth_window"],
+                )
+            )
+            for motif in kwargs["motifs"]:
+                regions_list = (
+                    kwargs["regions"]
+                    if isinstance(kwargs["regions"], list)
+                    else [kwargs["regions"]]
+                )
+                kwargs_plot_enrichment_profile_plot_enrichment_profile["motifs"] = [
+                    motif for _ in regions_list
+                ]
+                ax = dm.plot_enrichment_profile.plot_enrichment_profile(
+                    mod_file_names=[results["pileup"][0] for _ in regions_list],
+                    regions_list=regions_list,
+                    sample_names=["label" for _ in regions_list],
+                    **kwargs_plot_enrichment_profile_plot_enrichment_profile,
+                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
+        else:
+            print(
+                f"{test_case} skipped for plot_enrichment_profile.plot_enrichment_profile."
+            )
+
+    def test_unit__plot_enrichment_profile_by_regions(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_plot_enrichment_profile_by_regions = filter_kwargs_for_func(
+                dm.plot_enrichment_profile.by_regions,
+                kwargs,
+                extra_args=["window_size", "smooth_window"],
+            )
+            for motif in kwargs["motifs"]:
+                regions_list = (
+                    kwargs["regions"]
+                    if isinstance(kwargs["regions"], list)
+                    else [kwargs["regions"]]
+                )
+                ax = dm.plot_enrichment_profile.by_regions(
+                    mod_file_name=results["pileup"][0],
+                    regions_list=regions_list,
+                    motif=motif,
+                    sample_names=["label" for _ in regions_list],
+                    **kwargs_plot_enrichment_profile_by_regions,
+                )
+                assert isinstance(
+                    ax, Axes
+                ), f"{test_case}: plotting failed for {motif}."
+        else:
+            print(f"{test_case} skipped for plot_enrichment_profile.by_regions.")
+
+    def test_unit__plot_enrichment_profile_by_modification(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_plot_enrichment_profile_by_modification = filter_kwargs_for_func(
+                dm.plot_enrichment_profile.by_modification,
+                kwargs,
+                extra_args=["window_size", "smooth_window"],
+            )
+            ax = dm.plot_enrichment_profile.by_modification(
+                mod_file_name=results["pileup"][0],
+                **kwargs_plot_enrichment_profile_by_modification,
+            )
+            assert isinstance(ax, Axes), f"{test_case}: plotting failed."
+        else:
+            print(f"{test_case} skipped for plot_enrichment_profile.by_modification.")
+
+    def test_unit__plot_enrichment_by_dataset(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["pileup"][0] is not None:
+            kwargs_plot_enrichment_profile_by_dataset = filter_kwargs_for_func(
+                dm.plot_enrichment_profile.by_dataset,
+                kwargs,
+                extra_args=["window_size", "smooth_window"],
+            )
+            for motif in kwargs["motifs"]:
+                ax = dm.plot_enrichment_profile.by_dataset(
+                    mod_file_names=[results["pileup"][0]],
+                    motif=motif,
+                    **kwargs_plot_enrichment_profile_by_dataset,
+                )
+                assert isinstance(ax, Axes), f"{test_case}: plotting failed."
+        else:
+            print(f"{test_case} skipped for plot_enrichment_profile.by_dataset.")
+
+
+class TestPlotReadsSynthetic:
+    """
+    Tests plotting functionality in plot_reads.
+
+    This test simply checks that we can make plots from synthetic data without raising errors.
+    Appearance of plots is not verified.
+    """
+
+    def test_unit__plot_reads_plot_reads_synthetic(self):
+        ax = dm.plot_reads.plot_reads(
+            mod_file_name="test.fake", regions="test.bed", motifs=["A,0", "CG,0"]
+        )
+        assert isinstance(ax, Axes)
+
+
+@pytest.mark.parametrize(
+    "test_case,kwargs,results",
+    [(case, inputs, outputs) for case, (inputs, outputs) in test_matrix.items()],
+)
+class TestPlotReads:
+    def test_unit__plot_reads_plot_reads(
+        self,
+        test_case,
+        kwargs,
+        results,
+    ):
+        if results["extract"][0] is not None:
+            kwargs_plot_reads_plot_reads = filter_kwargs_for_func(
+                dm.plot_reads.plot_reads, kwargs
+            )
+            if kwargs["thresh"] is not None:
+                ax = dm.plot_reads.plot_reads(
+                    mod_file_name=results["extract"][0],
+                    **kwargs_plot_reads_plot_reads,
+                )
+                assert isinstance(ax, Axes), f"{test_case}: plotting failed."
+            else:  # if the extract parameters did not have a threshold, plot_reads.plot_reads should raise an error
+                with pytest.raises(ValueError) as excinfo:
+                    ax = dm.plot_reads.plot_reads(
+                        mod_file_name=results["extract"][0],
+                        **kwargs_plot_reads_plot_reads,
+                    )
+                assert "No threshold has been applied" in str(
+                    excinfo.value
+                ), f"{test_case}: unexpected exception {excinfo.value}"
+                # providing a threshold should be enough to run plot_reads.plot_reads without an error
+                kwargs_plot_reads_plot_reads["thresh"] = 0.75
+                ax = dm.plot_reads.plot_reads(
+                    mod_file_name=results["extract"][0],
+                    **kwargs_plot_reads_plot_reads,
+                )
+                assert isinstance(ax, Axes), f"{test_case}: plotting failed."
+        else:
+            print(f"{test_case} skipped for test_plot_reads_plot_reads.")


### PR DESCRIPTION
Modkit error catching, plot browser bug fixes, and other minor fixes. run_modkit.py is substantially restructured but the code function isn't very different, just some better pbar handling to make mypy happy and then catching and handling the return code from modkit so we detect early stopping. The index error for plot_read_browser was just caused by the drop_duplicates call for the dataframe when generating read spans not successfully dropping all duplicates; when we impute read start and end positions from modkit .txt files we can get small differences for the same read depending on the motif in question (for reasons previously discussed: we know where in the read the first  motif occurs, but we don't know for reads with possible indels or unaligned regions where precisely the start and end are).