### PR TITLE
Dm 38 subset reads for single read plotting

### DIFF
--- a/dimelo/load_processed.py
+++ b/dimelo/load_processed.py
@@ -605,6 +605,7 @@ def readwise_binary_modification_arrays(
     thresh: float | None = None,
     relative: bool = True,
     cores: int | None = None,  # currently unused
+    subset_parameters: dict | None = None,
 ) -> tuple[list[np.ndarray], np.ndarray[int], np.ndarray[str], dict | None]:
     """
     Pulls a list of read data out of a file containing processed read vectors, formatted with
@@ -647,6 +648,9 @@ def readwise_binary_modification_arrays(
             There is not currently a check for all reads being on the same chromosome if relative=False, but
             this could create unexpected behaviour for a the standard visualizations.
         cores: cores across which to parallelize processes (currently unused)
+        subset_parameters: Parameters to pass to the utils.random_sample() method, to subset the
+            reads to be returned. If not None, at least one of n or frac must be provided. The array
+            parameter should not be provided here.
 
     Returns:
         Returns a tuple of three arrays, of length (N_READS * len(mod_names)), and a dict of regions.

--- a/dimelo/load_processed.py
+++ b/dimelo/load_processed.py
@@ -1,5 +1,4 @@
 import gzip
-import random
 from collections import defaultdict
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
@@ -555,7 +554,7 @@ def read_vectors_from_hdf5(
 
     # If 'shuffle' appears anywhere in sort_by, we first shuffle the list
     if "shuffle" in sort_by:
-        random.shuffle(read_tuples_all)
+        utils.rng.shuffle(read_tuples_all)
 
     try:
         sort_by_indices = [

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -44,8 +44,7 @@ def plot_read_browser(
             and is only allowed to be passed as a single string option.
         hover: if False, disables display of information on mouse hover
         subset_parameters: Parameters to pass to the utils.random_sample() method, to subset the
-            reads to be returned. If not None, at least one of n or frac must be provided. The array
-            parameter should not be provided here.
+            reads to be returned. If not None, at least one of n or frac must be provided.
 
     Returns:
         plotly Figure object containing the plot
@@ -131,6 +130,10 @@ def format_browser_data(
     Returns:
         * dataframe defining the start, end, name, and desired y-index (sorting) of each read
         * dataframe defining all necessary information to place each modification event on the browser
+
+    TODO: There is an observed issue where there are duplicated reads; duplicates are currently thrown away. This only
+        manifests itself when subsetting reads, as different random subsets of the same requested size will show up as
+        different numbers of rows.
     """
     # Coerce read tuples to initial dataframe, throwing away unnecessary columns
     to_exclude = ["chromosome", "strand", "region_start", "region_end"]

--- a/dimelo/plot_read_browser.py
+++ b/dimelo/plot_read_browser.py
@@ -15,6 +15,7 @@ def plot_read_browser(
     single_strand: bool = False,
     sort_by: str | list[str] = "shuffle",
     hover: bool = True,
+    subset_parameters: dict | None = None,
     **kwargs,
 ) -> plotly.graph_objs.Figure:
     """
@@ -42,6 +43,9 @@ def plot_read_browser(
             more condensed visualization. Note that "collapse" is mutually exclusive with all other sorting options,
             and is only allowed to be passed as a single string option.
         hover: if False, disables display of information on mouse hover
+        subset_parameters: Parameters to pass to the utils.random_sample() method, to subset the
+            reads to be returned. If not None, at least one of n or frac must be provided. The array
+            parameter should not be provided here.
 
     Returns:
         plotly Figure object containing the plot
@@ -65,6 +69,7 @@ def plot_read_browser(
         single_strand=single_strand,
         sort_by=sort_by,
         calculate_mod_fractions=False,
+        subset_parameters=subset_parameters,
     )
 
     mod_vector_index = entry_labels.index("mod_vector")

--- a/dimelo/test_data.py
+++ b/dimelo/test_data.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-rng = np.random.default_rng()
+from . import utils
 
 
 def expspace_prob(num: int, a: float, b: float = 1) -> np.ndarray:
@@ -52,8 +52,8 @@ def fake_read_mod_calls(halfsize: int, read_type: str, max_prob: float) -> np.nd
             p_vec = np.flip(expspace_prob(num=halfsize, a=15, b=max_prob))
         case _:
             ValueError(f"Unknown read type {read_type}")
-    first_half = [np.random.binomial(n=1, p=x) for x in p_vec]
-    second_half = np.flip([np.random.binomial(n=1, p=x) for x in p_vec])
+    first_half = [utils.rng.binomial(n=1, p=x) for x in p_vec]
+    second_half = np.flip([utils.rng.binomial(n=1, p=x) for x in p_vec])
     return np.concatenate([first_half, second_half])
 
 

--- a/dimelo/utils.py
+++ b/dimelo/utils.py
@@ -450,9 +450,13 @@ def random_sample(
         this doesn't actually matter. However, it is being left off to prevent confusion for the end user.
     """
     size = pd.core.sample.process_sampling_size(n, frac, replace)
+    print(
+        f"n: {n}, frac: {frac}, replace: {replace}, len(array): {len(array)}, size: {size}"
+    )
     if size is None:
         assert frac is not None
         size = round(frac * len(array))
+    print(f"size: {size}")
     return rng.choice(
         a=array,
         size=size,

--- a/dimelo/utils.py
+++ b/dimelo/utils.py
@@ -35,6 +35,11 @@ DEFAULT_COLORSCALES = defaultdict(lambda: ["white", "grey"])
 DEFAULT_COLORSCALES.update([(k, ["white", v]) for k, v in DEFAULT_COLORS.items()])
 
 
+# Define the source of randomness for a variety of purposes throughout the package
+# TODO: how best to initialize seed for random state, to allow for reproducibility?
+rng = np.random.default_rng()
+
+
 def cores_to_run(cores):
     cores_avail = multiprocessing.cpu_count()
     if cores is None or cores > cores_avail:

--- a/dimelo/utils.py
+++ b/dimelo/utils.py
@@ -450,13 +450,9 @@ def random_sample(
         this doesn't actually matter. However, it is being left off to prevent confusion for the end user.
     """
     size = pd.core.sample.process_sampling_size(n, frac, replace)
-    print(
-        f"n: {n}, frac: {frac}, replace: {replace}, len(array): {len(array)}, size: {size}"
-    )
     if size is None:
         assert frac is not None
         size = round(frac * len(array))
-    print(f"size: {size}")
     return rng.choice(
         a=array,
         size=size,

--- a/dimelo/utils.py
+++ b/dimelo/utils.py
@@ -420,3 +420,45 @@ def smooth_rolling_mean(
         .mean()
         .values
     )
+
+
+def random_sample(
+    array: np.ndarray,
+    n: int | None = None,
+    frac: float | None = None,
+    replace: bool = False,
+    # shuffle: bool = True,
+):
+    """
+    Utility method for generating a random sample of the elements in an array. Always defaults to sampling along the first axis.
+    This means that for 2d arrays this method will return a subsample of the rows.
+
+    Handles n/frac specification like pandas.DataFrame.sample(): https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.sample.html.
+
+    Args:
+        array: Array to sample from
+        n: Number of elements to return; mutually exclusive with frac
+        frac: Fraction of elements to return; mutually exclusive with n
+        replace: When True, sample with replacement
+
+    Return: the requested random subset of the given array
+
+    NOTE: Outputs are not guaranteed to be in the same order as the original array. If ordering is required to be preserved, re-sort after.
+
+    TODO: enable non-uniform weights? Seems like too much to me...
+    TODO: shuffled outputs originally broke h5 loading, so it was turned off. However, because of the instability of the sampling order,
+        this doesn't actually matter. However, it is being left off to prevent confusion for the end user.
+    """
+    size = pd.core.sample.process_sampling_size(n, frac, replace)
+    if size is None:
+        assert frac is not None
+        size = round(frac * len(array))
+    return rng.choice(
+        a=array,
+        size=size,
+        replace=replace,
+        p=None,
+        axis=0,
+        # shuffle=shuffle
+        shuffle=False,
+    )


### PR DESCRIPTION
### Description
* Added a single source of randomness to `utils.py, for use in the future. All future random effects should reference `utils.rng`, an instance of `numpy.random.Generator`.
* Added read subset functionality to the read loaders in `load_processed.py`
* Percolated read subset functionality up to `plot_read_browser`

### Known issues, to bring up during review:
* There is not currently a way to set the random seed for deterministic results.
* The interface for specifying random selection is clunky. Is it overkill? Any better ideas?
* KNOWN BUG: Requesting the plotting of a specific number of reads in `plot_read_browser` will not always result in plotting the same number of reads.
  * This is because of the preexisting read duplication bug, documented elsewhere.
  * I deemed this to be out of scope of this simple PR. Do you disagree?
* Consistent with the other existing sources of randomness, there is no test infrastructure to verify this functionality.